### PR TITLE
Require user to log in

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,4 +3,5 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
   include SessionsHelper
+  before_action :logged_in_user
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,7 @@
 class SessionsController < ApplicationController
+  
+  skip_before_action :logged_in_user, only: [:new, :create]
+  
   def new
   end
 

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,4 +1,7 @@
 class StaticPagesController < ApplicationController
+  
+  skip_before_action :logged_in_user, only: [:home]
+  
   def home
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,3 @@
 module ApplicationHelper
+  
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -29,6 +29,15 @@ module SessionsHelper
     !current_user.nil?
   end
   
+  # Confirms a logged-in user.
+  def logged_in_user
+    unless logged_in?
+      #store_location
+      flash[:danger] = "Please log in."
+      redirect_to '/login'
+    end
+  end
+
   # Forgets a persistent session.
   def forget(user)
     user.forget


### PR DESCRIPTION
Require login via `before_action`
except for session controller and static page (home)